### PR TITLE
Fix fallback in chatbot response

### DIFF
--- a/chatbot/chatgui.py
+++ b/chatbot/chatgui.py
@@ -52,13 +52,17 @@ def predict_class(sentence, model):
     return return_list
 
 def getResponse(ints, intents_json):
+    if not ints:
+        return "I'm sorry, I didn't understand that."
+
     tag = ints[0]['intent']
     list_of_intents = intents_json['intents']
     for i in list_of_intents:
-        if(i['tag']== tag):
-            result = random.choice(i['responses'])
-            break
-    return result
+        if i['tag'] == tag:
+            return random.choice(i['responses'])
+
+    # Fallback in case tag is not found
+    return "I'm sorry, I didn't understand that."
 
 def chatbot_response(msg):
     ints = predict_class(msg, model)


### PR DESCRIPTION
## Summary
- fix crash when the chatbot cannot match an intent

## Testing
- `python -m py_compile chatbot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad07831708323bbeed1e7f5c33dcf