### PR TITLE
Fix apostrophe in adverse_drug intent

### DIFF
--- a/chatbot/intents.json
+++ b/chatbot/intents.json
@@ -25,7 +25,7 @@
          "context": [""]
         },
         {"tag": "adverse_drug",
-         "patterns": ["How to check Adverse drug reaction?", "Open adverse drugs module", "Give me a list of drugs causing adverse behavior", "List all drugs suitable for patient with adverse reaction", "Which drugs dont have adverse reaction?" ],
+         "patterns": ["How to check Adverse drug reaction?", "Open adverse drugs module", "Give me a list of drugs causing adverse behavior", "List all drugs suitable for patient with adverse reaction", "Which drugs don't have adverse reaction?" ],
          "responses": ["Navigating to Adverse drug reaction module"],
          "context": [""]
         },


### PR DESCRIPTION
## Summary
- correct grammar in `adverse_drug` intent question

## Testing
- `jq . chatbot/intents.json`

------
https://chatgpt.com/codex/tasks/task_e_684ad1495c2883239595786cb7d8aedd