### PR TITLE
Handle empty intent predictions

### DIFF
--- a/chatbot/chatgui.py
+++ b/chatbot/chatgui.py
@@ -62,7 +62,11 @@ def getResponse(ints, intents_json):
 
 def chatbot_response(msg):
     ints = predict_class(msg, model)
-    res = getResponse(ints, intents)
+    if not ints:
+        # When no intent is detected, fall back to the "noanswer" responses
+        res = getResponse([{'intent': 'noanswer'}], intents)
+    else:
+        res = getResponse(ints, intents)
     return res
 
 


### PR DESCRIPTION
## Summary
- safeguard `chatbot_response` when no intent is predicted

## Testing
- `python -m py_compile chatbot/chatgui.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad14e5c108323bf038742fd5a8d4a